### PR TITLE
Removed drunk 1 from 'of the Drunken Master.'

### DIFF
--- a/items/suffix.txt
+++ b/items/suffix.txt
@@ -103,7 +103,7 @@
 "litigious lawyer" gold=100
 "prickly porcupine" str=37 dex=37
 "sleeping sloth" con=95
-"drunken master" str=175 agi=75 drunk=1
+"drunken master" str=175 agi=75
 "soggy slug" agi=-50
 "Golden Ratio" gold=1618
 "speedrunning snake" agi=123


### PR DESCRIPTION
Found an item with drunk 1 on it. I remember hearing you say drunk is no longer in the game, so I figured I'd get rid of it.

I haven't yet figured out how to run the JS myself, but I only changed _one line_, so hopefully nothing will explode.
